### PR TITLE
Fix typo: `semantics` noun usage instead of incorrect `semantic`

### DIFF
--- a/documentation/tutorials/beginner_colab.ipynb
+++ b/documentation/tutorials/beginner_colab.ipynb
@@ -891,7 +891,7 @@
         "id": "MFmqpivc7x7p"
       },
       "source": [
-        "**TF-DF** attaches a **semantic** to each feature. This semantic controls how\n",
+        "**TF-DF** attaches a **semantics** to each feature. This semantics controls how\n",
         "the feature is used by the model. The following semantics are currently supported:\n",
         "\n",
         "-   **Numerical**: Generally for quantities or counts with full ordering. For\n",
@@ -906,13 +906,13 @@
         "    tokenized text. Can be a string or an integer in a sparse tensor or a\n",
         "    ragged tensor (recommended). The order/index of each item doesn't matter.\n",
         "\n",
-        "If not specified, the semantic is inferred from the representation type and shown in the training logs:\n",
+        "If not specified, the semantics is inferred from the representation type and shown in the training logs:\n",
         "\n",
-        "- int, float (dense or sparse) → Numerical semantic.\n",
-        "- str (dense or sparse) → Categorical semantic\n",
-        "- int, str (ragged) → Categorical-Set semantic\n",
+        "- int, float (dense or sparse) → Numerical semantics.\n",
+        "- str (dense or sparse) → Categorical semantics\n",
+        "- int, str (ragged) → Categorical-Set semantics\n",
         "\n",
-        "In some cases, the inferred semantic is incorrect. For example: An Enum stored as an integer is semantically categorical, but it will be detected as numerical. In this case, you should specify the semantic argument in the input. The `education_num` field of the Adult dataset is classical example.\n",
+        "In some cases, the inferred semantics is incorrect. For example: An Enum stored as an integer is semantically categorical, but it will be detected as numerical. In this case, you should specify the semantic argument in the input. The `education_num` field of the Adult dataset is classical example.\n",
         "\n",
         "This dataset doesn't contain such a feature. However, for the demonstration, we will make the model treat the `year` as a categorical feature:"
       ]


### PR DESCRIPTION
Checkout https://www.merriam-webster.com/dictionary/semantics
and https://www.merriam-webster.com/dictionary/semantic
for more info