### PR TITLE
Fixed typo: in the beginner_colab.ipynb

### DIFF
--- a/documentation/tutorials/beginner_colab.ipynb
+++ b/documentation/tutorials/beginner_colab.ipynb
@@ -545,7 +545,7 @@
         "id": "-ob3ovQ2seVY"
       },
       "source": [
-        "## Model tructure and feature importance\n",
+        "## Model structure and feature importance\n",
         "\n",
         "The overall structure of the model is show with `.summary()`. You will see:\n",
         "\n",


### PR DESCRIPTION
Fixed typo : `tructure` to structure in the beginner_colab.ipynb in the section :https://www.tensorflow.org/decision_forests/tutorials/beginner_colab#model_tructure_and_feature_importance