### PR TITLE
Fixed error message thrown when finding a feature with its semantic manually defined that is not present in the input features dict

### DIFF
--- a/tensorflow_decision_forests/tensorflow/core.py
+++ b/tensorflow_decision_forests/tensorflow/core.py
@@ -1071,7 +1071,7 @@ def infer_semantic(
   for key in manual_semantics.keys():
     if key not in inputs:
       raise ValueError(
-          f"Manual semantic \"{key}\" was found amount the input features: "
+          f"Manual semantic \"{key}\" was not found among the input features: "
           f"{inputs.keys()}")
 
   semantics = {}


### PR DESCRIPTION
Every time a feature with its semantic manually defined is not present in the input features dict, an error is raised. Its message was erroneously defined.
This PL fixes the message raised, allowing a clear identification of the issue when using decision forests.