### PR TITLE
Fixed typo: tensorflow_serving.md

### DIFF
--- a/documentation/tensorflow_serving.md
+++ b/documentation/tensorflow_serving.md
@@ -74,7 +74,7 @@ instructions.
 ### Import TF-DF in the TF-Serving project.
 
 Add the following lines in the `WORKSPACE` file located in the root directory of
-TF-Serving. The content should be placed near the top bellow `workspace(name =
+TF-Serving. The content should be placed near the top below `workspace(name =
 "tf_serving")`:
 
 ```python


### PR DESCRIPTION
Update Decision Forest serving documentation, fix typo `bellow` -> `below`