### PR TITLE
add python3.10 build

### DIFF
--- a/configure/setup.py
+++ b/configure/setup.py
@@ -75,6 +75,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",

--- a/tools/build_pip_package.sh
+++ b/tools/build_pip_package.sh
@@ -232,11 +232,13 @@ elif [ ${ARG} == "ALL_VERSIONS" ]; then
   # Compile with all the version of python using pyenv.
   assemble_files
   eval "$(pyenv init -)"
+  e2e_pyenv 3.10.2
   e2e_pyenv 3.9.2
   e2e_pyenv 3.8.7
   e2e_pyenv 3.7.7
 elif [ ${ARG} == "ALL_VERSIONS_ALREADY_ASSEMBLED" ]; then
   eval "$(pyenv init -)"
+  e2e_pyenv 3.10.2
   e2e_pyenv 3.9.2
   e2e_pyenv 3.8.7
   e2e_pyenv 3.7.7


### PR DESCRIPTION
There is no python3.10 build [published on pypi](https://pypi.org/project/tensorflow-decision-forests/#files). This PR is an attempt to fix the issue, but I'm not sure I understand your build process enough? 