### PR TITLE
Fix broken links in documentation

### DIFF
--- a/documentation/tutorials/beginner_colab.ipynb
+++ b/documentation/tutorials/beginner_colab.ipynb
@@ -86,8 +86,8 @@
         "1.  Train a model for regression.\n",
         "1.  Train a model for ranking.\n",
         "\n",
-        "Detailed documentation is available in the [user manual](https://github.com/tensorflow/decision-forests/documentation).\n",
-        "The [example directory](https://github.com/tensorflow/decision-forests/examples) contains other end-to-end examples."
+        "Detailed documentation is available in the [user manual](https://github.com/tensorflow/decision-forests/tree/main/documentation).\n",
+        "The [example directory](https://github.com/tensorflow/decision-forests/tree/main/examples) contains other end-to-end examples."
       ]
     },
     {
@@ -800,7 +800,7 @@
         "Trees.\n",
         "\n",
         "The learning algorithms are listed by calling `tfdf.keras.get_all_models()` or in the\n",
-        "[learner list](https://github.com/google/yggdrasil-decision-forests/manual/learners)."
+        "[learner list](https://github.com/google/yggdrasil-decision-forests/blob/main/documentation/learners.md)."
       ]
     },
     {
@@ -960,7 +960,7 @@
         "the quality of the final model. They are specified in the model class\n",
         "constructor. The list of hyper-parameters is visible with the *question mark* colab command (e.g. `?tfdf.keras.GradientBoostedTreesModel`).\n",
         "\n",
-        "Alternatively, you can find them on the [TensorFlow Decision Forest Github](https://github.com/tensorflow/decision-forests/keras/wrappers_pre_generated.py) or the [Yggdrasil Decision Forest documentation](https://github.com/google/yggdrasil_decision_forests/documentation/learners).\n",
+        "Alternatively, you can find them on the [TensorFlow Decision Forest Github](https://github.com/tensorflow/decision-forests/blob/main/tensorflow_decision_forests/keras/wrappers_pre_generated.py) or the [Yggdrasil Decision Forest documentation](https://github.com/google/yggdrasil-decision-forests/blob/main/documentation/learners.md).\n",
         "\n",
         "The default hyper-parameters of each algorithm matches approximatively the initial publication paper. To ensure consistancy, new features and their matching hyper-parameters are always disable by default. That's why it is a good idea to tune your hyper-parameters."
       ]


### PR DESCRIPTION
Fix broken links in documentation that are incorrectly mapped to wrong repository structure.