### PR TITLE
Fixed Broken link of directory_structure.md of YDF

### DIFF
--- a/documentation/developer_manual.md
+++ b/documentation/developer_manual.md
@@ -16,5 +16,5 @@ New logics should be implemented where relevant. When several layers are
 possibly relevant, the most generic layer should be favored.
 
 The directory structure of [TF-DF](directory_structure.md) and
-[YDF](https://github.com/google/yggdrasil-decision-forests/manual/directory_structure.md)
+[YDF](https://github.com/google/yggdrasil-decision-forests/blob/main/documentation/directory_structure.md)
 is a good start.


### PR DESCRIPTION
# Summary of changes

This PR fixes the broken link of directory_structure.md of YDF.

![bug](https://user-images.githubusercontent.com/88665786/160227483-73974470-dbfb-4acc-94b8-a451e84a9fa2.PNG)


## Results Before: 
The link provided in [TFDF](https://www.tensorflow.org/decision_forests/developer_manual) was broken and was not redirecting to directory_structure of YDF.

## Results After :
Fixed this issue, now it redirects to [YDF](https://github.com/google/yggdrasil-decision-forests/blob/main/documentation/directory_structure.md).

## Code before
```
https://github.com/google/yggdrasil-decision-forests/manual/directory_structure.md
````
## Code after
```
https://github.com/google/yggdrasil-decision-forests/blob/main/documentation/directory_structure.md
```

