### PR TITLE
Fixing dead examples link in beginner colab

### DIFF
--- a/documentation/tutorials/beginner_colab.ipynb
+++ b/documentation/tutorials/beginner_colab.ipynb
@@ -87,7 +87,7 @@
         "1.  Train a model for ranking.\n",
         "\n",
         "Detailed documentation is available in the [user manual](https://github.com/tensorflow/decision-forests/tree/main/documentation).\n",
-        "The [example directory](https://github.com/tensorflow/decision-forests/examples) contains other end-to-end examples."
+        "The [example directory](https://github.com/tensorflow/decision-forests/tree/main/examples) contains other end-to-end examples."
       ]
     },
     {


### PR DESCRIPTION
Fixing dead examples link in beginner colab. 

- [The previous link](https://github.com/tensorflow/decision-forests/examples)

- [The current link](https://github.com/tensorflow/decision-forests/tree/main/examples)