### PR TITLE
Modifications in Documentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ explains how to do inference of TF-DF models in C++ using Yggdrasil.
 
 ## Usage example
 
-A minimal end-to-end run looks as follow:
+A minimal end-to-end run looks as follows:
 
 ```python
 import tensorflow_decision_forests as tfdf

--- a/documentation/known_issues.md
+++ b/documentation/known_issues.md
@@ -75,7 +75,7 @@ does.
 
 ## No support for GPU / TPU.
 
-TF-DF does not support GPU or TPU training. Compiling with AVX instructions,
+TF-DF does not supports GPU or TPU training. Compiling with AVX instructions,
 however, may speed up serving.
 
 ## No support for [model_to_estimator](https://www.tensorflow.org/api_docs/python/tf/keras/estimator/model_to_estimator)

--- a/documentation/migration.md
+++ b/documentation/migration.md
@@ -129,8 +129,7 @@ sample of the dataset).
 
 **Rationale:** TF-DF shuffles access to the data internally after reading the
 full dataset into memory. TF-DF algorithms are deterministic (if the user does
-not change the random seed). Enabling shuffling will only make the algorithm non
-deterministic. Shuffling does make sense if the input dataset is ordered and the
+not change the random seed). Enabling shuffling will only make the algorithm non-deterministic. Shuffling does make sense if the input dataset is ordered and the
 input_fn is only going to read a sample of it (the sample should be random).
 However, this will make the training procedure non-deterministic.
 
@@ -170,8 +169,8 @@ Therefore, **it is a good idea to first try training on a (small) subset of the
 dataset.**
 
 The alternative solution is to use *distributed training*. Distributed training
-is a great way to increase the size of the dataset if multiple machines
-available. While all distributed algorithm are available to distribute the
+is a great way to increase the size of the dataset if multiple machines are
+available. While all the distributed algorithms are available to distribute the
 computation, not all of them are able to distribute the RAM usage. Check the
 [documentation](distributed_training.md) for more details.
 
@@ -186,7 +185,7 @@ computation, not all of them are able to distribute the RAM usage. Check the
     ~10GB (= 100 * 25 *10^6 * 4 bytes) of memory.
 
 *   Categorical-set features (e.g. tokenized text) take more memory (4 bytes per
-    token + 12 bytes per features).
+    token + 12 bytes per feature).
 
 **Consider your training time budget**
 
@@ -199,7 +198,7 @@ computation, not all of them are able to distribute the RAM usage. Check the
     sampling rate (`subsample` for GBT), and (3) the attribute sampling rate
     (`num_candidate_attributes_ratio`)
 
-*   Categorical-set features are more expensive that other features. The cost is
+*   Categorical-set features are more expensive than other features. The cost is
     controlled by the `categorical_set_split_greedy_sampling` parameter.
 
 *   Sparse Oblique features (disabled by default) give good results but are
@@ -345,7 +344,7 @@ It is possible to handle these features using the following strategies:
     *   Images: Using image with Random Forest was popular at some point (e.g.
 
         [Microsoft Kinect](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/BodyPartRecognition.pdf)
-        , but today, neural nets are state of the art.
+        , but today, neural nets are state-of-the-art.
 
     *   Time series:
         [[Moving statistics](http://framework.mathieu.guillame-bert.com/documentation_honey_tutorial_beginner)]
@@ -442,7 +441,7 @@ tfdf.keras.get_all_models()
 
 ### Model debugging
 
-This section presents some way you can look/debug/interpret the model. The
+This section presents some ways you can look/debug/interpret the model. The
 [beginner colab](tutorials/beginner_colab.ipynb) contains an end-to-end example.
 
 #### Simple model summary

--- a/documentation/tensorflow_serving.md
+++ b/documentation/tensorflow_serving.md
@@ -26,7 +26,7 @@ for a demonstration of TF-Serving + TF-DF.
 
 [TensorFlow Serving](https://www.tensorflow.org/tfx/guide/serving) is a system
 to run TensorFlow models in production environments. More precisely, TensorFlow
-Serving is a binary that expose model predictions through gRPC and HTTP. The
+Serving is a binary that exposes model predictions through gRPC and HTTP. The
 TF-Serving team publishes a
 [pre-compiled release](https://www.tensorflow.org/tfx/serving/docker) compatible
 with models only containing *canonical* TensorFlow ops.
@@ -57,7 +57,7 @@ Two options are available to run TF-DF in TF Serving:
     is an experimental solution to compile TF-Serving in TF-DF automatically. It
     is equivalent to the instruction below.
 
--   "TF-Serving + TF-Decision Forests" runs independently the Python
+-   "TF-Serving + TF-Decision Forests" runs independently of the Python
     installation of TF-Decision Forests.
 
 -   TF-Decision Forests models are backward compatible: For example, a model
@@ -194,4 +194,4 @@ tools/run_in_docker.sh -d tensorflow/serving:latest-devel bazel \
 
 Run
 [the TF-Serving+TF-DF example](https://github.com/tensorflow/decision-forests/tree/main/tools/tf_serving)
-to test to test your binary.
+to test your binary.

--- a/tensorflow_decision_forests/keras/core.py
+++ b/tensorflow_decision_forests/keras/core.py
@@ -301,7 +301,7 @@ class CoreModel(InferenceCoreModel):
     learner: The learning algorithm used to train the model. Possible values
       include (but at not limited to) "LEARNER_*".
     learner_params: Hyper-parameters for the learner. The list of available
-      hyper-parameters is available at [Learners](https://github.com/google/yggdrasil-decision-forests/blob/main/documentation/learners.md).
+      hyper-parameters is available at https://github.com/google/yggdrasil-decision-forests/blob/main/documentation/learners.md.
     features: Specify the list and semantic of the input features of the model.
       If not specified, all the available features will be used. If specified
       and if `exclude_non_specified_features=True`, only the features in

--- a/tensorflow_decision_forests/keras/core.py
+++ b/tensorflow_decision_forests/keras/core.py
@@ -301,17 +301,16 @@ class CoreModel(InferenceCoreModel):
     learner: The learning algorithm used to train the model. Possible values
       include (but at not limited to) "LEARNER_*".
     learner_params: Hyper-parameters for the learner. The list of available
-      hyper-parameters is available at
-      https://github.com/google/yggdrasil-decision-forests/blob/main/documentation/learners.md.
+      hyper-parameters is available at [Learners](https://github.com/google/yggdrasil-decision-forests/blob/main/documentation/learners.md).
     features: Specify the list and semantic of the input features of the model.
       If not specified, all the available features will be used. If specified
-      and if "exclude_non_specified_features=True", only the features in
+      and if `exclude_non_specified_features=True`, only the features in
       "features" will be used by the model. If "preprocessing" is used,
       "features" corresponds to the output of the preprocessing. In this case,
       it is recommended for the preprocessing to return a dictionary of tensors.
     exclude_non_specified_features: If true, only use the features specified in
       "features".
-    preprocessing: Functional keras model or @tf.function to apply on the input
+    preprocessing: Functional keras model or `@tf.function` to apply on the input
       feature before the model to train. This preprocessing model can consume
       and return tensors, list of tensors or dictionary of tensors. If
       specified, the model only "sees" the output of the preprocessing (and not
@@ -319,11 +318,11 @@ class CoreModel(InferenceCoreModel):
       models on top of each other. Unlike preprocessing done in the tf.dataset,
       the operation in "preprocessing" are serialized with the model.
     postprocessing: Like "preprocessing" but applied on the model output.
-    ranking_group: Only for task=Task.RANKING. Name of a tf.string feature that
+    ranking_group: Only for `task=Task.RANKING`. Name of a `tf.string` feature that
       identifies queries in a query/document ranking task. The ranking group is
       not added automatically for the set of features if
-      exclude_non_specified_features=false.
-    uplift_treatment: Only for task=Task.CATEGORICAL_UPLIFT and task=Task.
+      `exclude_non_specified_features=false`.
+    uplift_treatment: Only for `task=Task.CATEGORICAL_UPLIFT` and `task=Task`.
       NUMERICAL_UPLIFT. Name of an integer feature that identifies the treatment
       in an uplift problem. The value 0 is reserved for the control treatment.
     temp_directory: Temporary directory used to store the model Assets after the
@@ -357,7 +356,7 @@ class CoreModel(InferenceCoreModel):
       hyper-parameter of the model were changed such that an initially completed
       training is now incomplete (e.g. increasing the number of trees).
       Note: Training can only be resumed if the training datasets is exactly the
-        same (i.e. no reshuffle in the tf.data.Dataset).
+        same (i.e. no reshuffle in the `tf.data.Dataset`).
     check_dataset: If set to true, test if the dataset is well configured for
       the training: (1) Check if the dataset does contains any `repeat`
       operations, (2) Check if the dataset does contain a `batch` operation, (3)
@@ -371,7 +370,7 @@ class CoreModel(InferenceCoreModel):
     discretize_numerical_features: If true, discretize all the numerical
       features before training. Discretized numerical features are faster to
       train with, but they can have a negative impact on the model quality.
-      Using discretize_numerical_features=True is equivalent as setting the
+      Using `discretize_numerical_features=True` is equivalent as setting the
       feature semantic DISCRETIZED_NUMERICAL in the `feature` argument. See the
       definition of DISCRETIZED_NUMERICAL for more details.
     num_discretize_numerical_bins: Number of bins used when disretizing
@@ -820,15 +819,16 @@ class CoreModel(InferenceCoreModel):
     ==============
 
     It is recommended to use a Pandas Dataframe dataset and to convert it to
-    a TensorFlow dataset with "pd_dataframe_to_tf_dataset()":
-
+    a TensorFlow dataset with `pd_dataframe_to_tf_dataset()`:
+      ```python
       pd_dataset = pandas.Dataframe(...)
       tf_dataset = pd_dataframe_to_tf_dataset(dataset, label="my_label")
       model.fit(pd_dataset)
+      ```
 
     The following dataset formats are supported:
 
-      1. "x" is a tf.data.Dataset containing a tuple "(features, labels)".
+      1. "x" is a `tf.data.Dataset` containing a tuple "(features, labels)".
          "features" can be a dictionary a tensor, a list of tensors or a
          dictionary of tensors (recommended). "labels" is a tensor.
 
@@ -852,7 +852,7 @@ class CoreModel(InferenceCoreModel):
 
     Input features do not need to be normalized (e.g. dividing numerical values
     by the variance) or indexed (e.g. replacing categorical string values by
-    an integer). Additionnaly, missing values can be consumed natively.
+    an integer). Additionally, missing values can be consumed natively.
 
     Distributed training
     ====================
@@ -863,7 +863,7 @@ class CoreModel(InferenceCoreModel):
     In this case, the dataset is read asynchronously in between the workers. The
     distribution of the training depends on the learning algorithm.
 
-    Like for non-distributed training, the dataset should be read eactly once.
+    Like for non-distributed training, the dataset should be read exactly once.
     The simplest solution is to divide the dataset into different files (i.e.
     shards) and have each of the worker read a non overlapping subset of shards.
 
@@ -871,7 +871,7 @@ class CoreModel(InferenceCoreModel):
     dataset should not contain any repeat operation.
 
     Currently (to be changed), the validation dataset (if provided) is simply
-    feed to the "model.evaluate()" method. Therefore, it should satify Keras'
+    feed to the `model.evaluate()` method. Therefore, it should satisfy Keras'
     evaluate API. Notably, for distributed training, the validation dataset
     should be infinite (i.e. have a repeat operation).
 
@@ -881,6 +881,7 @@ class CoreModel(InferenceCoreModel):
     Here is a single example of distributed training using PSS for both dataset
     reading and training distribution.
 
+      ```python
       def dataset_fn(context, paths, training=True):
         ds_path = tf.data.Dataset.from_tensor_slices(paths)
 
@@ -937,6 +938,7 @@ class CoreModel(InferenceCoreModel):
       model.fit(sharded_train_paths)
       evaluation = model.evaluate(test_dataset, steps=num_test_examples //
         batch_size)
+      ```
 
     Args:
       x: Training dataset (See details above for the supported formats).
@@ -947,13 +949,13 @@ class CoreModel(InferenceCoreModel):
         be called equivalently before/after the fit function.
       verbose: Verbosity mode. 0 = silent, 1 = small details, 2 = full details.
       validation_steps: Number of steps in the evaluation dataset when
-        evaluating the trained model with model.evaluate(). If not specified,
+        evaluating the trained model with `model.evaluate()`. If not specified,
         evaluates the model on the entire dataset (generally recommended; not
         yet supported for distributed datasets).
       validation_data: Validation dataset. If specified, the learner might use
         this dataset to help training e.g. early stopping.
       sample_weight: Training weights. Note: training weights can also be
-        provided as the third output in a tf.data.Dataset e.g. (features, label,
+        provided as the third output in a `tf.data.Dataset` e.g. (features, label,
         weights).
       steps_per_epoch: [Parameter will be removed] Number of training batch to
         load before training the model. Currently, only supported for
@@ -962,7 +964,7 @@ class CoreModel(InferenceCoreModel):
         (integers) to a weight (float) value. Only available for non-Distributed
         training. For maximum compatibility, feed example weights through the
         tf.data.Dataset or using the `weight` argument of
-        pd_dataframe_to_tf_dataset.
+        `pd_dataframe_to_tf_dataset`.
       **kwargs: Extra arguments passed to the core keras model's fit. Note that
         not all keras' model fit arguments are supported.
 
@@ -1095,8 +1097,8 @@ class CoreModel(InferenceCoreModel):
 
       We recommend training / validating models with finite datasets. For
       backward compatibility with the early version of TF-DF, we also support
-      infinite dataset with specified number of steps (steps_per_epoch and
-      validation_steps arguments). Using a number of steps currently raises
+      infinite dataset with specified number of steps (`steps_per_epoch` and
+      `validation_steps` arguments). Using a number of steps currently raises
       a warning, and will later raise an error (and the logic be removed).
     """
 
@@ -1408,20 +1410,23 @@ class CoreModel(InferenceCoreModel):
       num_io_threads: int = 10):
     """Trains the model on a dataset stored on disk.
 
-    This solution is generally more efficient and easier that loading the
-    dataset with a tf.Dataset both for local and distributed training.
+    This solution is generally more efficient and easier than loading the
+    dataset with a `tf.Dataset` both for local and distributed training.
 
     Usage example:
 
       # Local training
-      model = model = keras.GradientBoostedTreesModel()
+      ```python
+      model = keras.GradientBoostedTreesModel()
       model.fit_on_dataset_path(
         train_path="/path/to/dataset.csv",
         label_key="label",
         dataset_format="csv")
       model.save("/model/path")
-
+      ```
+      
       # Distributed training
+      ```python
       with tf.distribute.experimental.ParameterServerStrategy(...).scope():
         model = model = keras.DistributedGradientBoostedTreesModel()
       model.fit_on_dataset_path(
@@ -1429,20 +1434,19 @@ class CoreModel(InferenceCoreModel):
         label_key="label",
         dataset_format="tfrecord+tfe")
       model.save("/model/path")
-
+      ```
+      
     Args:
-       train_path: Path to the training dataset. Support comma separated files,
-         shard and glob notation.
-       label_key: Name of the label column.
-       weight_key: Name of the weighing column.
-       ranking_key: Name of the ranking column.
-       valid_path: Path to the validation dataset. If not provided, or if the
-         learning algorithm does not support/need a validation dataset,
-         `valid_path` is ignored.
-       dataset_format: Format of the dataset. Should be one of the registered
-         dataset format (see
-         https://github.com/google/yggdrasil-decision-forests/blob/main/documentation/user_manual.md#dataset-path-and-format
-           for more details). The format "csv" always available but it is
+      train_path: Path to the training dataset. Supports comma separated files, shard and glob notation.
+      label_key: Name of the label column.
+      weight_key: Name of the weighing column.
+      ranking_key: Name of the ranking column.
+      valid_path: Path to the validation dataset. If not provided, or if the
+               learning algorithm does not supports/needs a validation dataset,
+               `valid_path` is ignored.
+      dataset_format: Format of the dataset. Should be one of the registered
+         dataset format (see [User Manual](https://github.com/google/yggdrasil-decision-forests/blob/main/documentation/user_manual.md#dataset-path-and-format)
+           for more details). The format "csv" is always available but it is
            generally only suited for small datasets.
       max_num_scanned_rows_to_accumulate_statistics: Maximum number of examples
         to scan to determine the statistics of the features (i.e. the dataspec,
@@ -1466,8 +1470,8 @@ class CoreModel(InferenceCoreModel):
         (Dense,Sparse,Ragged)TensorSpec (or structure of TensorSpec e.g.
         dictionary, list) corresponding to input signature of the model. If not
         specified, the input model signature is created by
-        "build_default_input_model_signature". For example, specify
-        "input_model_signature_fn" if an numerical input feature (which is
+        `build_default_input_model_signature`. For example, specify
+        `input_model_signature_fn` if an numerical input feature (which is
         consumed as DenseTensorSpec(float32) by default) will be feed
         differently (e.g. RaggedTensor(int64)).
       num_io_threads: Number of threads to use for IO operations e.g. reading a
@@ -1816,7 +1820,7 @@ def _list_explicit_arguments(func):
 def _parse_hp_template(template_name) -> Tuple[str, Optional[int]]:
   """Parses a template name as specified by the user.
 
-  Template can versionned:
+  Template can be versionned:
     "my_template@v5" -> Returns (my_template, 5)
   or non versionned:
     "my_template" -> Returns (my_template, None)
@@ -1967,7 +1971,7 @@ def _check_dataset(ds: tf.data.Dataset):
   Raise an exception otherwise.
 
   Args:
-    ds: A tf.data.Dataset.
+    ds: A `tf.data.Dataset`.
   """
 
   def error(message):
@@ -2020,7 +2024,7 @@ def _check_dataset(ds: tf.data.Dataset):
 
 
 def _get_operation(dataset, cls):
-  """Returns an operation defined by cls if present in dataset or else None."""
+  """Returns an operation defined by cls if present in dataset or else `None`."""
   try:
     if not isinstance(dataset, tf.data.Dataset):
       return None
@@ -2055,13 +2059,13 @@ def _contains_shuffle(dataset) -> bool:
 
 
 def _get_batch_size(dataset) -> Optional[int]:
-  """Returns batch_size if dataset contains a "batch()" operation or else None.
+  """Returns batch_size if dataset contains a "batch()" operation or else `None`.
 
   Args:
-    dataset: A tf.data.Dataset.
+    dataset: A `tf.data.Dataset`.
 
   Returns:
-    The batch size, or None if not batch operation was found.
+    The batch size, or `None` if not batch operation was found.
   """
 
   operation = _get_operation(dataset, dataset_ops.BatchDataset)

--- a/tensorflow_decision_forests/test_data/README.md
+++ b/tensorflow_decision_forests/test_data/README.md
@@ -2,6 +2,7 @@
 
 This directory only contains small files used for the unit tests.
 
-This directory structure is organized as follows: - model: Pre-trained models. -
-saved_model_adult_gbt: TF SavedModel containing a TF-DF GBT model trained with
+This directory structure is organized as follows: 
+- model: Pre-trained models. 
+- saved_model_adult_gbt: TF SavedModel containing a TF-DF GBT model trained with
 Keras.


### PR DESCRIPTION
## Changes done
-  Various typos (including grammatical and some repetitive words) and Markdown correction has been done in **decision-forests** documentations (**Documentation** directory).

- Changes in **keras/core.py**:
     - Few blocks of python code were not marked with markdown. That has been corrected;
     - Some links were not marked as hyperlinks. Those have been corrected;
     - Some typos have been fixed; and
     - **Usage examples** and **Args** of `fit_on_dataset_path` (**Cart Model**) were not formatted properly. They're fixed now.
