### PR TITLE
initial folder structure and interface definition for operators

### DIFF
--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/interval.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/interval.py
@@ -1,0 +1,3 @@
+from pandas import Timedelta as Interval
+
+# TODO: implement Interval class

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/operators/__init__.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/operators/__init__.py
@@ -1,0 +1,3 @@
+from .assign import AssignOperator
+from .base import Operator
+from .window import SimpleMovingAverageOperator, WindowOperator

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/operators/assign.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/operators/assign.py
@@ -1,0 +1,22 @@
+from temporal_feature_processor.sequences import EventSequence, FeatureSequence
+
+from .base import Operator
+
+
+class AssignOperator(Operator):
+    def __call__(self, event: EventSequence, feature: FeatureSequence) -> EventSequence:
+        """Assign a feature to an event.
+        Input event and feature must have same index.
+        Feature cannot have more than one row for a single index + timestamp occurence.
+        Output event will have same exact index and timestamps as input one.
+        Assignment can be understood as a left join on the index and timestamp columns.
+
+        Args:
+            event (EventSequence): event to assign the feature to.
+            feature (FeatureSequence): feature to assign to the event.
+
+        Returns:
+            EventSequence: a new event with the feature assigned.
+        """
+        # TODO: implement logic.
+        pass

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/operators/base.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/operators/base.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+from typing import Any, Union
+
+from temporal_feature_processor.sequences import EventSequence, FeatureSequence
+
+
+class Operator(ABC):
+    """Base class to define an operator's interface."""
+
+    @abstractmethod
+    def __call__(
+        self, *args: Any, **kwargs: Any
+    ) -> Union[EventSequence, FeatureSequence]:
+        """Apply the operator to its inputs.
+
+        Returns:
+            Union[EventSequence, FeatureSequence]: the output of the operator.
+        """

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/operators/window/__init__.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/operators/window/__init__.py
@@ -1,0 +1,2 @@
+from .base import WindowOperator
+from .simple_moving_average import SimpleMovingAverageOperator

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/operators/window/base.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/operators/window/base.py
@@ -1,0 +1,14 @@
+from pandas import Timedelta
+
+from temporal_feature_processor.sampling import Sampling
+
+from ..base import Operator
+
+
+class WindowOperator(Operator):
+    """Base class for window operators."""
+
+    def __init__(self, sampling: Sampling, window_length: Timedelta) -> None:
+        super().__init__()
+        self.sampling = sampling
+        self.window_length = window_length

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/operators/window/simple_moving_average.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/operators/window/simple_moving_average.py
@@ -1,0 +1,32 @@
+from typing import Union
+
+from pandas import Timedelta
+
+from temporal_feature_processor.sampling import Sampling
+from temporal_feature_processor.sequences import EventSequence, FeatureSequence
+
+from .base import WindowOperator
+
+
+class SimpleMovingAverageOperator(WindowOperator):
+    """Base class for window operators."""
+
+    def __init__(self, sampling: Sampling, window_length: Timedelta) -> None:
+        super().__init__(sampling=sampling, window_length=window_length)
+
+    def __call__(
+        self,
+        input: Union[EventSequence, FeatureSequence],
+    ) -> Union[EventSequence, FeatureSequence]:
+        """Apply a simple moving average to an event or feature.
+        If input is an event, the moving average will be computed for each of its features independently.
+
+        Args:
+            input (Union[EventSequence, FeatureSequence]): the input sequence to apply a simple moving average to.
+
+        Returns:
+            Union[EventSequence, FeatureSequence]: the output of the operator.
+                The output sequence will have the same type as the input sequence.
+        """
+        # TODO: implement logic
+        pass

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/sampling/__init__.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/sampling/__init__.py
@@ -1,0 +1,2 @@
+from .base import Sampling
+from .uniform_sampling import UniformSampling

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/sampling/base.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/sampling/base.py
@@ -1,0 +1,7 @@
+from abc import ABC
+
+
+class Sampling(ABC):
+    """Base class to define a sampling's interface."""
+
+    pass

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/sampling/uniform_sampling.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/sampling/uniform_sampling.py
@@ -1,0 +1,12 @@
+from pandas import Timestamp
+
+from temporal_feature_processor.interval import Interval
+
+from .base import Sampling
+
+
+class UniformSampling(Sampling):
+    def __init__(self, interval: Interval, start: Timestamp, end: Timestamp) -> None:
+        self.interval = interval
+        self.start = start
+        self.end = end

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/sequences/__init__.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/sequences/__init__.py
@@ -1,0 +1,2 @@
+from .event import EventSequence
+from .feature import FeatureSequence

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/sequences/event.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/sequences/event.py
@@ -1,0 +1,3 @@
+from pandas import DataFrame as EventSequence
+
+# TODO: implement EventSequence class

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/sequences/feature.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/sequences/feature.py
@@ -1,0 +1,3 @@
+from pandas import Series as FeatureSequence
+
+# TODO: implement FeatureSequence class


### PR DESCRIPTION
Initial folder structure for `operators`, `sampling` and `sequences` modules.

Implemented `EventSequence` and `FeatureSequence` as aliases of `pd.DataFrame` and `pd.Series` respectively. Same for `Interval` with `pd.Timedelta`.

Folder structure looks like this:
```
temporal_feature_processor
    ├── interval.py
    ├── operators
    │   ├── __init__.py
    │   ├── assign.py
    │   ├── base.py
    │   └── window
    │       ├── __init__.py
    │       ├── base.py
    │       └── simple_moving_average.py
    ├── sampling
    │   ├── __init__.py
    │   ├── base.py
    │   └── uniform_sampling.py
    └── sequences
        ├── __init__.py
        ├── event.py
        └── feature.py
```