### PR TITLE
TFP: assign operator & tests directory

### DIFF
--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/__init__.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/__init__.py
@@ -1,0 +1,3 @@
+from temporal_feature_processor.implementation.pandas.operators.assign import PandasAssignOperator
+from temporal_feature_processor.implementation.pandas.operators.base import PandasOperator
+from temporal_feature_processor.implementation.pandas.operators.window import PandasWindowOperator, PandasSimpleMovingAverageOperator

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/assign.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/assign.py
@@ -5,7 +5,7 @@ from .base import PandasOperator
 
 class PandasAssignOperator(PandasOperator):
 
-  def __call__(self, event: PandasEvent, features: PandasEvent) -> PandasEvent:
+  def __call__(self, event_1: PandasEvent, event_2: PandasEvent) -> PandasEvent:
     """Assign features to an event.
         Input event and features must have same index.
         Features cannot have more than one row for a single index + timestamp occurence.
@@ -19,5 +19,24 @@ class PandasAssignOperator(PandasOperator):
         Returns:
             PandasEvent: a new event with the features assigned.
         """
-    # TODO: implement logic.
-    pass
+    # assert indexes are the same
+    if event_1.index.names != event_2.index.names:
+      raise IndexError("Assign sequences must have the same index names.")
+
+    # get index column names
+    index, timestamp = self.split_index(event_1)
+
+    # check there's no repeated timestamps index-wise in the assigned sequence
+    if index:
+      max_timestamps = (
+          event_2.reset_index().groupby(index)[timestamp].value_counts().max())
+    else:
+      max_timestamps = event_2.reset_index()[timestamp].value_counts().max()
+
+    if max_timestamps > 1:
+      raise ValueError(
+          "Cannot have repeated timestamps in assigned EventSequence.")
+
+    # make assignment
+    output = event_1.join(event_2, how="left", rsuffix="y")
+    return output

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/base.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, List, Tuple
 
 from temporal_feature_processor.implementation.pandas.data.event import PandasEvent
 
@@ -14,3 +14,17 @@ class PandasOperator(ABC):
         Returns:
             PandasEvent: the output event of the operator.
         """
+
+  def split_index(self, event: PandasEvent) -> Tuple[List[str], str]:
+    """Split pandas' DataFrame index into (potentially) index columns and
+        a timestamp column.
+        Args:
+            event (PandasEvent): input PandasEvent (pandas DataFrame).
+        Returns:
+            Tuple[List[str], str]: output index and timestamp names.
+        """
+    index_timestamp = event.index.names
+    index = index_timestamp[:-1]
+    timestamp = index_timestamp[-1]
+
+    return index, timestamp

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/BUILD
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/BUILD
@@ -1,0 +1,17 @@
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+# Tests
+# =====
+py_test(
+    name = "assign_test",
+    srcs = ["assign_test.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//temporal_feature_processor/implementation/pandas/operators/tests/assign/test_data",
+        "//temporal_feature_processor/implementation/pandas/operators",
+        # absl/testing:absltest dep,
+    ],
+)

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/assign_test.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/assign_test.py
@@ -1,0 +1,37 @@
+from absl.testing import absltest
+
+import test_data
+from temporal_feature_processor.implementation.pandas.operators import PandasAssignOperator
+
+
+class AssignOperatorTest(absltest.TestCase):
+  base_data_dir = "temporal_feature_processor/tests/operators/assign/data"
+
+  def setUp(self) -> None:
+    self.operator = PandasAssignOperator()
+
+  def test_different_index(self) -> None:
+    self.assertRaises(IndexError, self.operator,
+                      test_data.different_index.INPUT_1,
+                      test_data.different_index.INPUT_2)
+
+  def test_repeated_timestamps(self) -> None:
+    self.assertRaises(ValueError, self.operator,
+                      test_data.repeated_timestamps.INPUT_1,
+                      test_data.repeated_timestamps.INPUT_1)
+
+  def test_with_idx_same_timestamps(self) -> None:
+    operator_output = self.operator(test_data.with_idx_same_timestamps.INPUT_1,
+                                    test_data.with_idx_same_timestamps.INPUT_2)
+    self.assertEqual(
+        True, test_data.with_idx_same_timestamps.OUTPUT.equals(operator_output))
+
+  def test_with_idx_more_timestamps(self) -> None:
+    operator_output = self.operator(test_data.with_idx_more_timestamps.INPUT_1,
+                                    test_data.with_idx_more_timestamps.INPUT_2)
+    self.assertEqual(
+        True, test_data.with_idx_more_timestamps.OUTPUT.equals(operator_output))
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/test_data/BUILD
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/test_data/BUILD
@@ -1,0 +1,46 @@
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+# All test data
+# =============
+
+py_library(
+    name = "test_data",
+    srcs = ["__init__.py"],
+    srcs_version = "PY3",
+    deps = [
+        ":different_index",
+        ":repeated_timestamps",
+        ":with_idx_more_timestamps",
+        ":with_idx_same_timestamps",
+    ],
+)
+
+# Indiviudual test data
+# =====================
+
+py_library(
+    name = "different_index",
+    srcs = ["different_index.py"],
+    srcs_version = "PY3",
+)
+
+py_library(
+    name = "repeated_timestamps",
+    srcs = ["repeated_timestamps.py"],
+    srcs_version = "PY3",
+)
+
+py_library(
+    name = "with_idx_more_timestamps",
+    srcs = ["with_idx_more_timestamps.py"],
+    srcs_version = "PY3",
+)
+
+py_library(
+    name = "with_idx_same_timestamps",
+    srcs = ["with_idx_same_timestamps.py"],
+    srcs_version = "PY3",
+)

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/test_data/__init__.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/test_data/__init__.py
@@ -1,0 +1,4 @@
+from temporal_feature_processor.implementation.pandas.operators.tests.assign.test_data import different_index
+from temporal_feature_processor.implementation.pandas.operators.tests.assign.test_data import repeated_timestamps
+from temporal_feature_processor.implementation.pandas.operators.tests.assign.test_data import with_idx_more_timestamps
+from temporal_feature_processor.implementation.pandas.operators.tests.assign.test_data import with_idx_same_timestamps

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/test_data/different_index.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/test_data/different_index.py
@@ -1,0 +1,55 @@
+import pandas as pd
+
+INPUT_1 = pd.DataFrame({
+    "user_id": [
+        151591562,
+        151591562,
+        151591562,
+        151591562,
+        151591562,
+    ],
+    "timestamp": [
+        pd.Timestamp("2020-11-09", tz="UTC"),
+        pd.Timestamp("2020-11-10", tz="UTC"),
+        pd.Timestamp("2020-11-10", tz="UTC"),
+        pd.Timestamp("2020-11-11", tz="UTC"),
+        pd.Timestamp("2020-11-12", tz="UTC"),
+    ],
+    "price": [
+        63.49,
+        63.49,
+        63.49,
+        133.21,
+        148.67,
+    ]
+}).set_index([
+    "user_id",
+    "timestamp",
+])
+
+INPUT_2 = pd.DataFrame({
+    "product_id": [
+        666964,
+        666964,
+        666964,
+        574016,
+        372306,
+    ],
+    "timestamp": [
+        pd.Timestamp("2020-11-09", tz="UTC"),
+        pd.Timestamp("2020-11-10", tz="UTC"),
+        pd.Timestamp("2020-11-10", tz="UTC"),
+        pd.Timestamp("2020-11-11", tz="UTC"),
+        pd.Timestamp("2020-11-12", tz="UTC"),
+    ],
+    "price": [
+        126.98,
+        126.98,
+        126.98,
+        266.42,
+        297.34,
+    ]
+}).set_index([
+    "product_id",
+    "timestamp",
+])

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/test_data/repeated_timestamps.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/test_data/repeated_timestamps.py
@@ -1,0 +1,55 @@
+import pandas as pd
+
+INPUT_1 = pd.DataFrame({
+    "user_id": [
+        151591562,
+        151591562,
+        151591562,
+        191562515,
+        191562515,
+    ],
+    "timestamp": [
+        pd.Timestamp("2020-12-20", tz="UTC"),
+        pd.Timestamp("2020-12-20", tz="UTC"),
+        pd.Timestamp("2020-12-20", tz="UTC"),
+        pd.Timestamp("2020-12-21", tz="UTC"),
+        pd.Timestamp("2020-12-22", tz="UTC")
+    ],
+    "price": [
+        63.49,
+        63.49,
+        63.49,
+        133.21,
+        148.67,
+    ]
+}).set_index([
+    "user_id",
+    "timestamp",
+])
+
+INPUT_2 = pd.DataFrame({
+    "user_id": [
+        151591562,
+        151591562,
+        151591562,
+        191562515,
+        191562515,
+    ],
+    "timestamp": [
+        pd.Timestamp("2020-11-15", tz="UTC"),
+        pd.Timestamp("2020-11-16", tz="UTC"),
+        pd.Timestamp("2020-11-17", tz="UTC"),
+        pd.Timestamp("2020-11-18", tz="UTC"),
+        pd.Timestamp("2020-11-18", tz="UTC")
+    ],
+    "price": [
+        190.47,
+        190.47,
+        190.47,
+        399.63,
+        446.01,
+    ]
+}).set_index([
+    "user_id",
+    "timestamp",
+])

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/test_data/with_idx_more_timestamps.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/test_data/with_idx_more_timestamps.py
@@ -1,0 +1,95 @@
+import pandas as pd
+
+INPUT_1 = pd.DataFrame({
+    "product_id": [
+        666964,
+        666964,
+        666964,
+        574016,
+        372306,
+    ],
+    "timestamp": [
+        pd.Timestamp("2013-01-01", tz="UTC"),
+        pd.Timestamp("2013-01-02", tz="UTC"),
+        pd.Timestamp("2013-01-03", tz="UTC"),
+        pd.Timestamp("2013-01-04", tz="UTC"),
+        pd.Timestamp("2013-01-05", tz="UTC"),
+    ],
+    "sales": [
+        0.0,
+        1091.0,
+        919.0,
+        953.0,
+        1160.0,
+    ]
+}).set_index([
+    "product_id",
+    "timestamp",
+])
+
+INPUT_2 = pd.DataFrame({
+    "product_id": [
+        666964,
+        666964,
+        666964,
+        574016,
+        372306,
+        574016,
+        372306,
+    ],
+    "timestamp": [
+        pd.Timestamp("2013-01-01", tz="UTC"),
+        pd.Timestamp("2013-01-02", tz="UTC"),
+        pd.Timestamp("2013-01-03", tz="UTC"),
+        pd.Timestamp("2013-01-04", tz="UTC"),
+        pd.Timestamp("2013-01-05", tz="UTC"),
+        pd.Timestamp("2013-01-06", tz="UTC"),
+        pd.Timestamp("2013-01-07", tz="UTC"),
+    ],
+    "costs": [
+        0.0,
+        740.0,
+        508.0,
+        573.0,
+        790.0,
+        124.0,
+        235.0,
+    ]
+}).set_index([
+    "product_id",
+    "timestamp",
+])
+
+OUTPUT = pd.DataFrame({
+    "product_id": [
+        666964,
+        666964,
+        666964,
+        574016,
+        372306,
+    ],
+    "timestamp": [
+        pd.Timestamp("2013-01-01", tz="UTC"),
+        pd.Timestamp("2013-01-02", tz="UTC"),
+        pd.Timestamp("2013-01-03", tz="UTC"),
+        pd.Timestamp("2013-01-04", tz="UTC"),
+        pd.Timestamp("2013-01-05", tz="UTC"),
+    ],
+    "sales": [
+        0.0,
+        1091.0,
+        919.0,
+        953.0,
+        1160.0,
+    ],
+    "costs": [
+        0.0,
+        740.0,
+        508.0,
+        573.0,
+        790.0,
+    ]
+}).set_index([
+    "product_id",
+    "timestamp",
+])

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/test_data/with_idx_same_timestamps.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/tests/assign/test_data/with_idx_same_timestamps.py
@@ -1,0 +1,89 @@
+import pandas as pd
+
+INPUT_1 = pd.DataFrame({
+    "product_id": [
+        666964,
+        666964,
+        666964,
+        574016,
+        372306,
+    ],
+    "timestamp": [
+        pd.Timestamp("2013-01-01", tz="UTC"),
+        pd.Timestamp("2013-01-02", tz="UTC"),
+        pd.Timestamp("2013-01-03", tz="UTC"),
+        pd.Timestamp("2013-01-04", tz="UTC"),
+        pd.Timestamp("2013-01-05", tz="UTC"),
+    ],
+    "sales": [
+        0.0,
+        1091.0,
+        919.0,
+        953.0,
+        1160.0,
+    ]
+}).set_index([
+    "product_id",
+    "timestamp",
+])
+
+INPUT_2 = pd.DataFrame({
+    "product_id": [
+        666964,
+        666964,
+        666964,
+        574016,
+        372306,
+    ],
+    "timestamp": [
+        pd.Timestamp("2013-01-01", tz="UTC"),
+        pd.Timestamp("2013-01-02", tz="UTC"),
+        pd.Timestamp("2013-01-03", tz="UTC"),
+        pd.Timestamp("2013-01-04", tz="UTC"),
+        pd.Timestamp("2013-01-05", tz="UTC"),
+    ],
+    "costs": [
+        0.0,
+        740.0,
+        508.0,
+        573.0,
+        790.0,
+    ]
+}).set_index([
+    "product_id",
+    "timestamp",
+])
+
+OUTPUT = pd.DataFrame({
+    "product_id": [
+        666964,
+        666964,
+        666964,
+        574016,
+        372306,
+    ],
+    "timestamp": [
+        pd.Timestamp("2013-01-01", tz="UTC"),
+        pd.Timestamp("2013-01-02", tz="UTC"),
+        pd.Timestamp("2013-01-03", tz="UTC"),
+        pd.Timestamp("2013-01-04", tz="UTC"),
+        pd.Timestamp("2013-01-05", tz="UTC"),
+    ],
+    "sales": [
+        0.0,
+        1091.0,
+        919.0,
+        953.0,
+        1160.0,
+    ],
+    "costs": [
+        0.0,
+        740.0,
+        508.0,
+        573.0,
+        790.0,
+    ]
+}).set_index([
+    "product_id",
+    "timestamp",
+])

--- a/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/window/__init__.py
+++ b/tensorflow_decision_forests/contrib/temporal_feature_processor/temporal_feature_processor/implementation/pandas/operators/window/__init__.py
@@ -1,0 +1,2 @@
+from temporal_feature_processor.implementation.pandas.operators.window.base import PandasWindowOperator
+from temporal_feature_processor.implementation.pandas.operators.window.simple_moving_average import PandasSimpleMovingAverageOperator


### PR DESCRIPTION
This PR implements the assign operator's logic in Python via Pandas as well as part of the tests of the operator. Opened as a draft PR for now since we should first merge #151 and #156. 

The proposed structure for the tests directory is as follows:
```
tests/
├─ sampling/
├─ operators/
│  ├─ assign/
│  │  ├─ data/
│  │  │  ├─ with_idx_more_timestamps/
│  │  │  │  ├─ input_1.csv
│  │  │  │  ├─ input_2.csv
│  │  │  │  ├─ output.csv
│  │  │  ├─ with_idx_same_timestamps/
│  │  │  │  ├─ input_1.csv
│  │  │  │  ├─ input_2.csv
│  │  │  │  ├─ output.csv
│  │  │  ├─ repeated_timestamps/
│  │  │  │  ├─ input.csv
│  │  ├─ assign_test.py
├─ sequences/
```

The directory structure of the tests is analogous to the code's. Each test (e.g. `assign`) has its own `.py` file defining the tests (using Abseil) as well as a `data` directory containing the data to run each of the tests.