### PR TITLE
correct regex used to generate bazel workspace

### DIFF
--- a/tools/test_bazel.sh
+++ b/tools/test_bazel.sh
@@ -58,7 +58,7 @@ pip list
 # Get the commit SHA
 short_commit_sha=$(${PYTHON} -c 'import tensorflow as tf; print(tf.__git_version__)' | tail -1 | grep -o "\-g[0-9a-f]*" | cut -c 3-)
 # Grep will close the pipe before curl is finished, which creates an error we ignore.
-commit_sha=$(curl -SsL https://github.com/tensorflow/tensorflow/commit/${short_commit_sha} 2>/dev/null |  grep -o -m 1 $short_commit_sha'\([0-9]\|[a-f]\)\{29\}')
+commit_sha=$(curl -SsL https://github.com/tensorflow/tensorflow/commit/${short_commit_sha} 2>/dev/null |  grep -m1 -oE $short_commit_sha'[a-f0-9]{10,}')
 # Update TF dependency to the chosen version
 sed -i'.bak' -e "s/strip_prefix = \"tensorflow-2\.[0-9]\+\.[0-9]\+\(-rc[0-9]\+\)\?\",/strip_prefix = \"tensorflow-${commit_sha}\",/" WORKSPACE
 sed -i'.bak' -e "s|\"https://github.com/tensorflow/tensorflow/archive/v.\+\.zip\"|\"https://github.com/tensorflow/tensorflow/archive/${commit_sha}.zip\"|" WORKSPACE


### PR DESCRIPTION
As outlined in #175 the regex responsible for extracting the long SHA hash from the github commit page seems to be not working right.

Example when tensorflow is at tensorflow/tensorflow@0db597d0

This commits long hash is `0db597d0d758aba578783b5bf46c889700a45085`.
However, the regex produces `0db597d0d758aba578783b5bf46c889700a45`, which is three chars short (the regex limits it at 29 chars, which is incorrect):
```bash
$ curl -SsL https://github.com/tensorflow/tensorflow/commit/0db597d0 2>/dev/null |  grep -o -m 1 '0db597d0\([0-9]\|[a-f]\)\{29\}'

0db597d0d758aba578783b5bf46c889700a45
```
This causes the build to fail because bazel cant find the correct archive, even if the download of the zip from github *does* succeed:
```bash
$ bazel --bazelrc=tensorflow_bazelrc build //tensorflow_decision_forests/component/...:all //tensorflow_decision_forests/contrib/...:all //tensorflow_decision_forests/keras //tensorflow_decision_forests/keras:grpc_worker_main --config=linux --action_env TF_HEADER_DIR=/usr/local/lib/python3.10/site-packages/tensorflow/include --action_env TF_SHARED_LIBRARY_DIR=/usr/local/lib/python3.10/site-packages/tensorflow --action_env TF_SHARED_LIBRARY_NAME=libtensorflow_framework.so.2

...
ERROR: An error occurred during the fetch of repository 'org_tensorflow':
   Traceback (most recent call last):
	File "/root/.cache/bazel/_bazel_root/8b529a028cc7ed10f109d406a8d13d99/external/bazel_tools/tools/build_defs/repo/http.bzl", line 132, column 45, in _http_archive_impl
		download_info = ctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Error extracting /root/.cache/bazel/_bazel_root/8b529a028cc7ed10f109d406a8d13d99/external/org_tensorflow/temp13364651896073939090/0db597d0d758aba578783b5bf46c889700a45.zip to /root/.cache/bazel/_bazel_root/8b529a028cc7ed10f109d406a8d13d99/external/org_tensorflow/temp13364651896073939090: Prefix "tensorflow-0db597d0d758aba578783b5bf46c889700a45" was given, but not found in the archive. Here are possible prefixes for this archive: "tensorflow-0db597d0d758aba578783b5bf46c889700a45085".
ERROR: /decision-forests/WORKSPACE:12:13: fetching http_archive rule //external:org_tensorflow: Traceback (most recent call last):
	File "/root/.cache/bazel/_bazel_root/8b529a028cc7ed10f109d406a8d13d99/external/bazel_tools/tools/build_defs/repo/http.bzl", line 132, column 45, in _http_archive_impl
		download_info = ctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Error extracting /root/.cache/bazel/_bazel_root/8b529a028cc7ed10f109d406a8d13d99/external/org_tensorflow/temp13364651896073939090/0db597d0d758aba578783b5bf46c889700a45.zip to /root/.cache/bazel/_bazel_root/8b529a028cc7ed10f109d406a8d13d99/external/org_tensorflow/temp13364651896073939090: Prefix "tensorflow-0db597d0d758aba578783b5bf46c889700a45" was given, but not found in the archive. Here are possible prefixes for this archive: "tensorflow-0db597d0d758aba578783b5bf46c889700a45085".
ERROR: Error computing the main repository mapping: no such package '@org_tensorflow//tensorflow': java.io.IOException: Error extracting /root/.cache/bazel/_bazel_root/8b529a028cc7ed10f109d406a8d13d99/external/org_tensorflow/temp13364651896073939090/0db597d0d758aba578783b5bf46c889700a45.zip to /root/.cache/bazel/_bazel_root/8b529a028cc7ed10f109d406a8d13d99/external/org_tensorflow/temp13364651896073939090: Prefix "tensorflow-0db597d0d758aba578783b5bf46c889700a45" was given, but not found in the archive. Here are possible prefixes for this archive: "tensorflow-0db597d0d758aba578783b5bf46c889700a45085".
```
Using the corrected version provides the correct hash:
```bash
$ curl -SsL https://github.com/tensorflow/tensorflow/commit/0db597d0 | grep -m1 -oE '0db597d0[a-f0-9]{10,}'

0db597d0d758aba578783b5bf46c889700a45085
```
When having applied the patch, the build succeeds again.
To be safe, i used a regex which matches on all strings longer than 10 chars.

Fixes #175