### PR TITLE
tf_keras doesn't run in colab, revert back to tf.keras for working demo

### DIFF
--- a/documentation/tf_df_in_tf_js.md
+++ b/documentation/tf_df_in_tf_js.md
@@ -45,10 +45,9 @@ import tensorflow as tf
 import tensorflow_decision_forests as tfdf
 import tensorflowjs as tfjs
 from google.colab import files
-import tf_keras
 
 # Load the model with Keras
-model = tf_keras.models.load_model("/tmp/my_saved_model/")
+model = tf.keras.models.load_model("/tmp/my_saved_model/")
 
 # Convert the keras model to TensorFlow.js
 tfjs.converters.tf_saved_model_conversion_v2.convert_keras_model_to_graph_model(model, "./tfjs_model")


### PR DESCRIPTION
i copied the latest code as of today from [the decision forests tutorial](https://www.tensorflow.org/decision_forests/tf_df_in_tf_js) and i noticed `tf_keras` doesn't work in colab. 

to get it to work, i had to undo the changes made to `documentation/tf_df_in_tf_js.md` (see part of [`b9a4cf1`](https://github.com/tensorflow/decision-forests/commit/b9a4cf110b055c41c48286a2484ba1b3750533c9#diff-5bd7de03547f8a53e213559339585412efeb7185dd091a3fc2f4de680be19fef)) back to using `tf.keras` for the second python code snippet, in order for it to successfully work in colab to download the zip file. i'm working on making sure the final js step works in my own local demo in order to fix https://github.com/tensorflow/decision-forests/issues/205 in a separate PR